### PR TITLE
Update urijs to 1.19.6.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "release": "npm publish"
   },
   "dependencies": {
-    "urijs": "1.19.4"
+    "urijs": "^1.19.6"
   },
   "devDependencies": {
     "@ava/babel": "1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4664,10 +4664,10 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-urijs@1.19.4:
-  version "1.19.4"
-  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.4.tgz#3953d7dacd801336c17921ee8c5518b150cbf965"
-  integrity sha512-2YF/wdFu02Gsly/wyx+S/f5w/oCF0ihVSgK/Sn8fcY/ZYMYtqxgi03Vi3V7HqyQP8mj8xHMuNFTBIPufmPRdoA==
+urijs@^1.19.6:
+  version "1.19.6"
+  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.6.tgz#51f8cb17ca16faefb20b9a31ac60f84aa2b7c870"
+  integrity sha512-eSXsXZ2jLvGWeLYlQA3Gh36BcjF+0amo92+wHPyN1mdR8Nxf75fuEuYTd9c0a+m/vhCjRK0ESlE9YNLW+E1VEw==
 
 url-parse-lax@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
I also made the version constraint semver-compatible, rather than a specific version so that consumers have more flexibility in using a different version of this library.