### PR TITLE
Update urijs 1.19.8 to 1.19.10

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4670,9 +4670,9 @@ uri-js@^4.2.2:
     punycode "^2.1.0"
 
 urijs@^1.19.6:
-  version "1.19.9"
-  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.9.tgz#3b15844835de3732866d420768c16f24be7d3e65"
-  integrity sha512-v0V+v5F3NQFt6TX0GpA2NKyrpythDJI+PHRo66sUIDP/U6cXbm6NqLVcXylQGwiwW5VYNj+OAei3EU0ALj9AWg==
+  version "1.19.10"
+  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.10.tgz#8e2fe70a8192845c180f75074884278f1eea26cb"
+  integrity sha512-EzauQlgKuJgsXOqoMrCiePBf4At5jVqRhXykF3Wfb8ZsOBMxPcfiVBcsHXug4Aepb/ICm2PIgqAUGMelgdrWEg==
 
 url-parse-lax@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Updates to the latest available urijs version to overcome a couple of CVEs:

https://nvd.nist.gov/vuln/detail/CVE-2022-0868 
https://nvd.nist.gov/vuln/detail/CVE-2022-24723 