### PR TITLE
Update urijs 1.19.10 to 1.19.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "release": "npm publish"
   },
   "dependencies": {
-    "urijs": "^1.19.6"
+    "urijs": "^1.19.11"
   },
   "devDependencies": {
     "@ava/babel": "1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4669,10 +4669,10 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-urijs@^1.19.6:
-  version "1.19.10"
-  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.10.tgz#8e2fe70a8192845c180f75074884278f1eea26cb"
-  integrity sha512-EzauQlgKuJgsXOqoMrCiePBf4At5jVqRhXykF3Wfb8ZsOBMxPcfiVBcsHXug4Aepb/ICm2PIgqAUGMelgdrWEg==
+urijs@^1.19.11:
+  version "1.19.11"
+  resolved "https://maven.forgerock.org/artifactory/api/npm/npm-virtual/urijs/-/urijs-1.19.11.tgz#204b0d6b605ae80bea54bea39280cdb7c9f923cc"
+  integrity sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==
 
 url-parse-lax@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
As the title says, updates urijs 1.19.10 to 1.19.11 to avoid issues noted in:

- https://nvd.nist.gov/vuln/detail/CVE-2022-1243
- https://nvd.nist.gov/vuln/detail/CVE-2022-1233